### PR TITLE
adds CountTableRows and ConcurrentCountTableRows to NewMigrationContext

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -236,6 +236,8 @@ type logger interface {
 func NewMigrationContext() *MigrationContext {
 	return &MigrationContext{
 		Uuid:                                uuid.NewV4().String(),
+		CountTableRows:                      true,
+		ConcurrentCountTableRows:            true,
 		defaultNumRetries:                   60,
 		ChunkSize:                           1000,
 		InspectorConnectionConfig:           mysql.NewConnectionConfig(),


### PR DESCRIPTION
For more accurate completion estimates for large tables, set CountTableRows and ConcurrentCountTableRows to true when creating a NewMigrationContext.